### PR TITLE
Fix speaking in calls when camera is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Reverts Discord's 2021 rebrand (font, colors, reactions, mentions, loading scree
 - Powercord
 - BetterDiscord
 - Vizality
+- BeautifulDiscord
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Reverts Discord's 2021 rebrand (font, colors, reactions, mentions, loading scree
 - Powercord
 - BetterDiscord
 - Vizality
-- BeautifulDiscord
 
 ## Screenshots
 

--- a/src/general/other.css
+++ b/src/general/other.css
@@ -4,6 +4,11 @@
   background-color: var(--old-green);
 }
 
+/* Also fix the colorables when they're active or being hovered over, for example when hovering over the call buttons */
+.colorable-1bkp8v.green-plH-Mj.active-1QRrIS, .colorable-1bkp8v.green-plH-Mj:hover {
+  background: var(--old-green);
+}
+
 /* Verified check mark color */
 .verified-1eC5dy {
   color: var(--old-green);

--- a/src/general/other.css
+++ b/src/general/other.css
@@ -24,6 +24,11 @@
   box-shadow: inset 0 0 0 2px var(--old-green), inset 0 0 0 3px #2f3136;
 }
 
+/* And fix speaking in call when your camera is enabled */
+.border-3dQmSY.speaking-WDn8Wm {
+  box-shadow: inset 0 0 0 2px var(--old-green), inset 0 0 0 3px #000;
+}
+
 /* Revert new Nitro icon by setting item */
 .premiumTabItem-1QTfBr .icon-Zc-uZZ {
   display: none;

--- a/src/main.css
+++ b/src/main.css
@@ -193,6 +193,11 @@ body {
   background-color: var(--old-green);
 }
 
+/* Also fix the colorables when they're active or being hovered over, for example when hovering over the call buttons */
+.colorable-1bkp8v.green-plH-Mj.active-1QRrIS, .colorable-1bkp8v.green-plH-Mj:hover {
+  background: var(--old-green);
+}
+
 /* Verified check mark color */
 .verified-1eC5dy {
   color: var(--old-green);

--- a/src/main.css
+++ b/src/main.css
@@ -208,6 +208,11 @@ body {
   box-shadow: inset 0 0 0 2px var(--old-green), inset 0 0 0 3px #2f3136;
 }
 
+/* And fix speaking in call when your camera is enabled */
+.border-3dQmSY.speaking-WDn8Wm {
+  box-shadow: inset 0 0 0 2px var(--old-green), inset 0 0 0 3px #000;
+}
+
 /* Revert new Nitro icon by setting item */
 .premiumTabItem-1QTfBr .icon-Zc-uZZ {
   display: none;


### PR DESCRIPTION
Speaking in calls when a camera is enabled seems to use a different rule than when nobody in call has cameras enabled, despite being almost identical.

- [x] Fix speaking in calls with camera on
- [x] Fix the join call button when hovering