### PR TITLE
Correct reactions.

### DIFF
--- a/src/components/reactions.css
+++ b/src/components/reactions.css
@@ -3,9 +3,7 @@
   border-radius: .25rem;
   background: var(--background-modifier-selected);
 
-  border-color: transparent !important;
-
-  margin-right: 3px;
+  border: none;
 }
 
 .reaction-1hd86g .reactionCount-2mvXRV {
@@ -13,7 +11,7 @@
 }
 
 .reaction-1hd86g .reactionInner-15NvIl {
-  padding: 0 4.5px;
+  padding: 0 .375rem;
 }
 
 /* Self reactions */


### PR DESCRIPTION
Corrects padding, removes incorrect margin adjustment (the 0.25rem that's still in used by latest Discord CSS is correct), removes reaction borders instead of hiding them, they didn't exist previously.